### PR TITLE
Allow targets, schemes and folders named with spaces

### DIFF
--- a/build_and_run_unit_tests.sh
+++ b/build_and_run_unit_tests.sh
@@ -2,27 +2,27 @@
 # Script to compile and run unit tests from the command line
 
 # The scheme and target name of the main app
-MAIN_APP_TARGET=$1
+MAIN_APP_TARGET="$1"
 
 # The scheme and target name of the unit tests
-UNIT_TEST_TARGET=$2
+UNIT_TEST_TARGET="$2"
 
 # The path to libXcodeTest.a, if not in current directory
-PATH_TO_XCODE_TEST_LIB=$3
+PATH_TO_XCODE_TEST_LIB="$3"
 
 # Output variable defaults to current directory of not specified
 LINK_TO_XCODE_TEST_LIB=""
 if [[ "${PATH_TO_XCODE_TEST_LIB}" != "" ]]; then
-  XCODE_TEST_ABS_LIB_PATH=`pwd`/${PATH_TO_XCODE_TEST_LIB}
+  XCODE_TEST_ABS_LIB_PATH="${PWD}/${PATH_TO_XCODE_TEST_LIB}"
   LINK_TO_XCODE_TEST_LIB="-lXcodeTest -L \"${XCODE_TEST_ABS_LIB_PATH}\""
 else
-  CURRENT_PATH=`pwd`
+  CURRENT_PATH="${PWD}"
   LINK_TO_XCODE_TEST_LIB="-lXcodeTest -L\"${CURRENT_PATH}\""
 fi
 
 # Calculate the variables to feed into the build
-OUTPUT_DIR=/tmp/xcodetest/${MAIN_APP_TARGET}
-XCODE_TEST_PATH=${OUTPUT_DIR}/${UNIT_TEST_TARGET}.octest/${UNIT_TEST_TARGET}
+OUTPUT_DIR="/tmp/xcodetest/${MAIN_APP_TARGET}"
+XCODE_TEST_PATH="${OUTPUT_DIR}/${UNIT_TEST_TARGET}.octest/${UNIT_TEST_TARGET}"
 XCODE_TEST_LDFLAGS="-ObjC -framework SenTestingKit ${LINK_TO_XCODE_TEST_LIB} -F \"$\(SDKROOT\)/Developer/Library/Frameworks\""
 
 # More reliable if the simulator is not already running
@@ -34,7 +34,7 @@ echo "Building unit test bundle"
 echo "========================="
 echo "xcodebuild -sdk iphonesimulator -scheme ${UNIT_TEST_TARGET} build CONFIGURATION_BUILD_DIR=\"${OUTPUT_DIR}\""
 echo "========================="
-xcodebuild -sdk iphonesimulator -scheme ${UNIT_TEST_TARGET} build CONFIGURATION_BUILD_DIR="${OUTPUT_DIR}"
+xcodebuild -sdk iphonesimulator -scheme "${UNIT_TEST_TARGET}" build CONFIGURATION_BUILD_DIR="${OUTPUT_DIR}"
 if [[ $? != 0 ]]; then
   echo "Failed to build unit tests!"
   exit $?
@@ -46,7 +46,7 @@ echo "Building app with xcodetest"
 echo "==========================="
 echo "xcodebuild -sdk iphonesimulator -scheme ${MAIN_APP_TARGET} build CONFIGURATION_BUILD_DIR=\"${OUTPUT_DIR}\" XCODE_TEST_LDFLAGS=\"${XCODE_TEST_LDFLAGS}\""
 echo "==========================="
-xcodebuild -sdk iphonesimulator -scheme ${MAIN_APP_TARGET} build CONFIGURATION_BUILD_DIR="${OUTPUT_DIR}" XCODE_TEST_LDFLAGS="${XCODE_TEST_LDFLAGS}"
+xcodebuild -sdk iphonesimulator -scheme "${MAIN_APP_TARGET}" build CONFIGURATION_BUILD_DIR="${OUTPUT_DIR}" XCODE_TEST_LDFLAGS="${XCODE_TEST_LDFLAGS}"
 if [[ $? != 0 ]]; then
   echo "Failed to build app!"
   exit $?
@@ -67,13 +67,13 @@ echo "    In Xcode: set Other Linker Flags to include \$(XCODE_TEST_LDFLAGS)"
 echo "================="
 
 # Run the app in the simulator, will automatically load and run unit tests
-OUT_FILE=${OUTPUT_DIR}/waxsim.out
-XCODE_TEST_PATH=${XCODE_TEST_PATH} waxsim ${OUTPUT_DIR}/${MAIN_APP_TARGET}.app -SenTest All > ${OUT_FILE} 2>&1
-cat ${OUT_FILE}
+OUT_FILE="${OUTPUT_DIR}/waxsim.out"
+XCODE_TEST_PATH="${XCODE_TEST_PATH}" waxsim "${OUTPUT_DIR}/${MAIN_APP_TARGET}.app" -SenTest All > "${OUT_FILE}" 2>&1
+cat "${OUT_FILE}"
 osascript -e 'tell app "iPhone Simulator" to quit'
 
 # if there was a failure, show what waxsim was hiding and crucially return with a non-zero exit code
-grep -q ": error:" $OUT_FILE
+grep -q ": error:" "$OUT_FILE"
 success=`exec grep -c ": error:" $OUT_FILE`
 
 if [[ $success != 0 ]]; then


### PR DESCRIPTION
The script didn't work if I had a scheme called, for example, "My Great App".
